### PR TITLE
Fix collapse merging to cover entire color component

### DIFF
--- a/agent_explain/2024-06-11-bfs-collapse.md
+++ b/agent_explain/2024-06-11-bfs-collapse.md
@@ -1,0 +1,12 @@
+# 2024-06-11
+
+## What I did
+- Implemented a more robust `Puzzle.collapse` that merges full connected components of the same color instead of only immediate neighbors. This ensures color propagation behaves as expected when solving puzzles.
+- Verified the updated solver now finds a 3-move solution and runs without errors.
+- Ensured pyright reports zero issues.
+
+## Why I did it
+- Previous collapse logic merged only direct neighbors which could disconnect regions and prevent finding optimal solutions. Using a DFS based component merge fixes the bug.
+
+## Questions
+- None.


### PR DESCRIPTION
## Summary
- merge all connected same-color nodes in `Puzzle.collapse`
- document change in agent report

## Testing
- `pyright`
- `python solver.py`

------
https://chatgpt.com/codex/tasks/task_e_6864fde13c488326879dd3a0bd8e494f