### PR TITLE
Add InfiniteColor enum

### DIFF
--- a/agent_explain/2025-07-02-infinite-color.md
+++ b/agent_explain/2025-07-02-infinite-color.md
@@ -1,0 +1,13 @@
+# 2025-07-02
+
+## What I did
+- Added a new module `color.py` defining `InfiniteColor`.
+- Implemented `_missing_` to dynamically create enum members like `Color_6` when instantiated with out-of-range integers.
+- Verified iteration still only covers the base four colors and pyright reports no issues.
+
+## Why I did it
+- Needed a color enum that gracefully handles arbitrary indices for puzzles with unlimited color slots.
+- This allows requesting `InfiniteColor(n)` for any index without raising an error while maintaining compatibility with the existing `Color` ordering.
+
+## Questions
+- None.

--- a/color.py
+++ b/color.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import Any
+
+class InfiniteColor(Enum):
+    ORANGE = 0
+    DARK_BLUE = 1
+    CREAM = 2
+    TURQUOISE = 3
+
+    @classmethod
+    def _missing_(cls, value: Any) -> "InfiniteColor":
+        if isinstance(value, int):
+            name = f"Color_{value}"
+            if name in cls.__members__:
+                return cls.__members__[name]
+            member = object.__new__(cls)
+            member._name_ = name
+            member._value_ = value
+            cls._value2member_map_[value] = member
+            cls._member_map_[name] = member
+            return member
+        raise ValueError(f"{value!r} is not a valid {cls.__name__}")


### PR DESCRIPTION
## Summary
- add module `color.py` defining `InfiniteColor` enum
- document work in `agent_explain/2025-07-02-infinite-color.md`

## Testing
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_68650ac53940832689ec9fabe215e4d9